### PR TITLE
I don't think we need to support python 3.3 any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.6
   - 3.5
   - 3.4
-  - 3.3
 matrix:
   include:
     - python: 3.6


### PR DESCRIPTION
AWS Lambda supports at least 3.6.

I am hoping this fixes build failures in e.g. https://github.com/mozilla-services/sign-xpi-lib/pull/11.